### PR TITLE
Clean up left-over/unused code

### DIFF
--- a/Alpha2MQTT/Alpha2MQTT.ino
+++ b/Alpha2MQTT/Alpha2MQTT.ino
@@ -979,7 +979,6 @@ void mqttReconnect()
 			
 		}
 
-		if (!subscribed)
 #ifdef DEBUG
 		sprintf(_debugOutput, "MQTT Failed: RC is %d\r\nTrying again in five seconds...", _mqtt.state());
 		Serial.println(_debugOutput);


### PR DESCRIPTION
Remove "dead" line of code.
At first glance, I thought this was a bug because the "if" line should have curly braces around the debug lines AND
the delay.  But then I realized that "subscribed" will ALWAYS be false here.  So the code was working correctly, even
without the curly braces and the "if" was superfluous and can/should be removed.
