### PR TITLE
Support 128x64 displays, resolve compiler warnings, improve debugging

### DIFF
--- a/Alpha2MQTT/Alpha2MQTT.ino
+++ b/Alpha2MQTT/Alpha2MQTT.ino
@@ -1025,11 +1025,15 @@ modbusRequestAndResponseStatusValues addStateInfo(uint16_t registerAddress, char
 
 		// Let the onward process also know if the buffer failed.
 		resultAddedToPayload = addToPayload(stateAddition);
+#if 0	// Enable this debug to see when registers are read and added successfully
+		sprintf(_debugOutput, "addStateInfo succeeded for: 0x%04x, registerAddress);
+		Serial.println(_debugOutput);
+#endif
 	}
 	else
 	{
 #ifdef DEBUG
-		sprintf(_debugOutput, "Failed to addStateInfo for: %u, Result was: %d", registerAddress, result);
+		sprintf(_debugOutput, "Failed to addStateInfo for: 0x%04x, result was: %d", registerAddress, result);
 		Serial.println(_debugOutput);
 #endif
 	}

--- a/Alpha2MQTT/Alpha2MQTT.ino
+++ b/Alpha2MQTT/Alpha2MQTT.ino
@@ -386,7 +386,7 @@ static struct mqttState _mqttAllHandledRegisters[] PROGMEM =
 // Wemos OLED Shield set up. 64x48
 // Pins D1 D2 if ESP8266
 // Pins GPIO22 and GPIO21 (SCL/SDA) with optional reset on GPIO13 if ESP32
-Adafruit_SSD1306 _display(-1); // No RESET Pin
+Adafruit_SSD1306 _display(LED_WIDTH_PIXELS, LED_HEIGHT_PIXELS);	// No RESET Pin
 
 
 

--- a/Alpha2MQTT/Definitions.h
+++ b/Alpha2MQTT/Definitions.h
@@ -40,8 +40,24 @@ Customise these options as per README.txt.  Please read README.txt before contin
 
 // Define the width and height of the display in pixels.
 // The WeMos OLED shield used in the original project is 64x48 but most SSD1306 displays sold on Amazon are 128x64
-#define LED_WIDTH_PIXELS		64		// 128
-#define LED_HEIGHT_PIXELS		48		// 64
+#if 0
+// Suggested settings for 128x64 display
+# define LED_WIDTH_PIXELS			128
+# define LED_HEIGHT_PIXELS		64
+# define LED_LINE_HEIGHT			(LED_HEIGHT_PIXELS/4)
+# define LED_LINE0_VPOS				12
+# define OLED_CHARACTER_WIDTH 16
+// Use a larger font to make use of the additional vertical pixels
+# define LED_FONT							FreeSansBold9pt7b
+#else
+// Default settings for WeMos 64x48 display
+# define LED_WIDTH_PIXELS			64
+# define LED_HEIGHT_PIXELS		48
+# define LED_LINE_HEIGHT			12
+# define LED_LINE0_VPOS				0
+# define OLED_CHARACTER_WIDTH 11
+// Leave LED_FONT undefined to use the default font
+#endif
 
 // If values for some registers such as voltage or temperatures appear to be out by a decimal place or two, try the following:
 // Documentation declares 1V - However Presume 0.1 as result appears to reflect this.  I.e. my voltage reading was 2421, * 0.1 for 242.1
@@ -958,7 +974,6 @@ enum modbusRequestAndResponseStatusValues
 #define MAX_FORMATTED_DATA_VALUE_LENGTH 129
 #define MAX_DATA_TYPE_DESC_LENGTH 20
 #define MAX_FORMATTED_DATE_LENGTH 21
-#define OLED_CHARACTER_WIDTH 11
 
 
 // This is the request and return object for the sendModbus() function.

--- a/Alpha2MQTT/Definitions.h
+++ b/Alpha2MQTT/Definitions.h
@@ -32,6 +32,16 @@ Customise these options as per README.txt.  Please read README.txt before contin
 #error You must only select one microprocessor from the list
 #endif
 
+// If the board definition for your ESP32 board doesn't define LED_BUILTIN, define it here
+// For example, some ESP32 modules work when configured as "ESP32 Dev Module" but that board file doesn't define LED_BUILTIN for that board
+#if defined(CONFIG_IDF_TARGET_ESP32) && !defined(LED_BUILTIN)
+# define LED_BUILTIN    2       // LED pin on ESP32 Devkit
+#endif
+
+// Define the width and height of the display in pixels.
+// The WeMos OLED shield used in the original project is 64x48 but most SSD1306 displays sold on Amazon are 128x64
+#define LED_WIDTH_PIXELS		64		// 128
+#define LED_HEIGHT_PIXELS		48		// 64
 
 // If values for some registers such as voltage or temperatures appear to be out by a decimal place or two, try the following:
 // Documentation declares 1V - However Presume 0.1 as result appears to reflect this.  I.e. my voltage reading was 2421, * 0.1 for 242.1

--- a/Alpha2MQTT/RS485Handler.cpp
+++ b/Alpha2MQTT/RS485Handler.cpp
@@ -352,18 +352,26 @@ modbusRequestAndResponseStatusValues RS485Handler::listenResponse(modbusRequestA
 	if (timedOut)
 	{
 #ifdef DEBUG
-		sprintf(_debugOutput, "Timed Out (inByteNumZeroIndexed): %d", inByteNumZeroIndexed);
-		Serial.println(_debugOutput);
-		sprintf(_debugOutput, "Timed Out (gotSlaveID): %d", gotSlaveID);
-		Serial.println(_debugOutput);
-		sprintf(_debugOutput, "Timed Out (gotFunctionCode): %d", gotFunctionCode);
-		Serial.println(_debugOutput);
-		sprintf(_debugOutput, "Timed Out (resp->functionCode): %d", resp->functionCode);
-		Serial.println(_debugOutput);
-		sprintf(_debugOutput, "Timed Out (gotData): %d", gotData);
-		Serial.println(_debugOutput);
-		sprintf(_debugOutput, "Timed Out (resp->dataSize): %d", resp->dataSize);
-		Serial.println(_debugOutput);
+		if (inByteNumZeroIndexed == 0)
+		{
+			// This is the common case of nothing received - there is no point in printing the rest
+			Serial.println("Timed out (no data received)");
+		}
+		else
+		{
+			sprintf(_debugOutput, "Timed Out (inByteNumZeroIndexed): %d", inByteNumZeroIndexed);
+			Serial.println(_debugOutput);
+			sprintf(_debugOutput, "Timed Out (gotSlaveID): %d", gotSlaveID);
+			Serial.println(_debugOutput);
+			sprintf(_debugOutput, "Timed Out (gotFunctionCode): %d", gotFunctionCode);
+			Serial.println(_debugOutput);
+			sprintf(_debugOutput, "Timed Out (resp->functionCode): %d", resp->functionCode);
+			Serial.println(_debugOutput);
+			sprintf(_debugOutput, "Timed Out (gotData): %d", gotData);
+			Serial.println(_debugOutput);
+			sprintf(_debugOutput, "Timed Out (resp->dataSize): %d", resp->dataSize);
+			Serial.println(_debugOutput);
+		}
 #endif
 	}
 


### PR DESCRIPTION
1. Support 128x64 OLED displays, which are more readily available than the 64x48 display used in the original project. The default is still 64x48 for compatibility with previous versions.
2. Simplify the debug output when no response is received from the inverter, and add an option to display successful as well as unsuccessful data retrieval.
3. Resolve many of the warnings generated when compiling the project, to make the code more robust.
4. Add option to define LED_BUILTIN in the Definitions.h file to support ESP32 boards for which it isn't already defined.